### PR TITLE
patch(): pass `filename` to `transform` func

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ module.exports = {
     plugins: [
         ['transform-imports', {
             'my-library': {
-                transform: function(importName, matches) {
+                transform: function(importName, matches, filename) {
                     return `my-library/etc/${importName.toUpperCase()}`;
                 },
                 preventFullImport: true,

--- a/index.js
+++ b/index.js
@@ -95,6 +95,8 @@ module.exports = function() {
                 var opts = state.opts[opt];
                 var hasOpts = !!opts;
 
+                var matches = isRegexp ? getMatchesFromSource(opt, source) : [];
+
                 if (hasOpts) {
                     if (!opts.transform) {
                         barf('transform option is required for module ' + source);
@@ -102,7 +104,7 @@ module.exports = function() {
 
                     var transforms = [];
 
-                    var fullImports = path.node.specifiers.filter(function(specifier) { return specifier.type !== 'ImportSpecifier' });
+                    var fullImports = path.node.specifiers.filter(function (specifier) { return specifier.type !== 'ImportSpecifier' })
                     var memberImports = path.node.specifiers.filter(function(specifier) { return specifier.type === 'ImportSpecifier' });
 
                     if (fullImports.length > 0) {
@@ -114,17 +116,9 @@ module.exports = function() {
                             barf('import of entire module ' + source + ' not allowed due to preventFullImport setting');
                         }
 
-                        if (memberImports.length > 0) {
-                            // Swap out the import with one that doesn't include member imports.  Member imports should each get their own import line
-                            // transform this:
-                            //      import Bootstrap, { Grid } from 'react-bootstrap';
-                            // into this:
-                            //      import Bootstrap from 'react-bootstrap';
-                            transforms.push(types.importDeclaration(fullImports, types.stringLiteral(source)));
-                        }
+                        var replace = transform(opts.transform, undefined, matches, state.filename);
+                        transforms.push(types.importDeclaration(fullImports, types.stringLiteral(replace)));                        
                     }
-
-                    var matches = isRegexp ? getMatchesFromSource(opt, source) : [];
 
                     memberImports.forEach(function(memberImport) {
                         // Examples of member imports:

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function barf(msg) {
     throw new Error('babel-plugin-transform-imports: ' + msg);
 }
 
-function transform(transformOption, importName, matches) {
+function transform(transformOption, importName, matches, filename) {
     var isFunction = typeof transformOption === 'function';
     if (/\.js$/i.test(transformOption) || isFunction) {
         var transformFn;
@@ -62,7 +62,7 @@ function transform(transformOption, importName, matches) {
             barf('expected transform function to be exported from ' + transformOption);
         }
 
-        return transformFn(importName, matches);
+        return transformFn(importName, matches, filename);
     }
 
     return transformOption.replace(/\$\{\s?([\w\d]*)\s?\}/ig, function(str, g1) {
@@ -138,7 +138,7 @@ module.exports = function() {
                         else if (opts.memberConverter === 'snake') importName = snake(importName);
                         else if (typeof(opts.memberConverter) === 'function') importName = opts.memberConverter(importName);
 
-                        var replace = transform(opts.transform, importName, matches);
+                        var replace = transform(opts.transform, importName, matches, state.filename);
 
                         var newImportSpecifier = (opts.skipDefaultConversion)
                             ? memberImport

--- a/index.js
+++ b/index.js
@@ -71,10 +71,17 @@ function transform(transformOption, importName, matches, filename) {
     });
 }
 
+const replacements = [];
+
 module.exports = function() {
     return {
         visitor: {
             ImportDeclaration: function (path, state) {
+                // skip transforming imports that were already transformed
+                if (replacements.indexOf(path.node) > -1) {
+                    return;
+                }
+
                 // https://github.com/babel/babel/tree/master/packages/babel-types#timportdeclarationspecifiers-source
 
                 // path.node has properties 'source' and 'specifiers' attached.
@@ -165,6 +172,7 @@ module.exports = function() {
                     });
 
                     if (transforms.length > 0) {
+                        replacements.push(...transforms);
                         path.replaceWithMultiple(transforms);
                     }
                 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "https://bitbucket.org/amctheatres/babel-transform-imports",
   "scripts": {
-    "test": "node_modules/.bin/mocha --compilers js:babel-register"
+    "test": "mocha --compilers js:babel-register"
   },
   "author": "AMC Theatres",
   "license": "ISC",


### PR DESCRIPTION
### Motivation
When transforming relative files it is crucial to have the filename accessible to make decisions.
Extremely useful when using only babel + module scripts + importmaps 

### Changes
Passed the full filename for the state to the function.
Tried to add a test but it doesn't have the state as it does in a real call.
Also, I made the transformer skip the transformed imports.